### PR TITLE
Hotfix for US daily extracts.

### DIFF
--- a/covid_app/extracts/cdc/us_daily_cases_extract.py
+++ b/covid_app/extracts/cdc/us_daily_cases_extract.py
@@ -10,7 +10,7 @@ from functools import cached_property
 from config.secrets import SODA_APP_TOKEN
 
 
-EXTRACT_URL = 'sandbox.demo.socrata.com'
+EXTRACT_URL = 'data.cdc.gov'
 DATASET_ID = '9mfq-cb36'
 START_DATE = date(2020, 3, 1)
 

--- a/covid_app/extracts/hhs/us_daily_patients_extract.py
+++ b/covid_app/extracts/hhs/us_daily_patients_extract.py
@@ -10,7 +10,7 @@ from functools import cached_property
 from config.secrets import SODA_APP_TOKEN
 
 
-EXTRACT_URL = 'sandbox.demo.socrata.com'
+EXTRACT_URL = 'healthdata.gov'
 DATASET_ID = 'g62h-syeh'
 START_DATE = date(2020, 3, 1)
 

--- a/covid_app/extracts/hhs/us_daily_tests_extract.py
+++ b/covid_app/extracts/hhs/us_daily_tests_extract.py
@@ -10,7 +10,7 @@ from functools import cached_property
 from config.secrets import SODA_APP_TOKEN
 
 
-EXTRACT_URL = 'sandbox.demo.socrata.com'
+EXTRACT_URL = 'healthdata.gov'
 DATASET_ID = 'j8mb-icvb'
 START_DATE = date(2020, 3, 1)
 


### PR DESCRIPTION
The domain I had been using `sandbox.demo.socrata.com` now returns `404`. That domain came from the [sodapy README](https://github.com/xmunoz/sodapy). (They should make it more clear what value to use there.)

Changed it to the source domain listed in the dataset pages. For example:

- https://dev.socrata.com/foundry/data.cdc.gov/9mfq-cb36